### PR TITLE
Add no-more-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A list of cool web-based applications that have been built on Shuttle.
 - [Kitsune](https://github.com/aumetra/kitsune/tree/aumetra/shuttle) - A self-hostable ActivityPub-based social media server, like Mastodon. Uses Vue as a frontend.
 - [Rustypaste](https://github.com/orhun/rustypaste) - A simple web service that lets you host and share long plain text. 
 - [Github API Dashboard](https://github.com/marc2332/ghboard) - A dashboard that tracks your Github contributions. Uses Dioxus as a frontend, powered by the Github GraphQL API. [(Demo)](https://ghboard.shuttleapp.rs/user/demonthos)
+- [no-more-json](https://github.com/beyarkay/no-more-json) - Fed up with massive JSON objects? Just give `no-more-json` an API endpoint and a [`jq`](https://jqlang.github.io/jq/) query. `no-more-json` will apply that query to the JSON returned by the endpoint, and give you the (much smaller) result.
 
 ## Libraries
 


### PR DESCRIPTION
[`no-more-json`](https://github.com/beyarkay/no-more-json) is a little utility API I built using shuttle which filters JSON API responses for you, so you don't have to deal with massive JSON blobs consuming your network bandwidth and memory.

Here's an example from the readme:


You can curl `wttr.in` to get weather data, and adding `format=j1` will return the data in JSON format. Unfortunately the returned JSON is massive (48kb), especially if we only want the current temperature (2 bytes: `27`):

```
curl 'wttr.in/Detroit?format=j1'
{
    "current_condition": [
        {
            "FeelsLikeC": "27",     <-- ✅ The thing we want
            [...]                   <-- ⚠️ 29 other lines we don't want ):
        }
    ],
    "nearest_area": [...],          <-- ⚠️ 25 lines we don't want ):
    "request": [...],               <-- ⚠️ 4 lines we don't want 
    "weather": [...]                <-- ⚠️ 1248 lines we don't want! 
}
```

The jq query we'd use to extract the feels-like temperature in Celcius is `.current_condition[0].FeelsLikeC`

We can use `no-more-json` to make a request to the wttr.in endpoint, extract
the result, and then run the jq query for us on that result, so we just get
back a nice scalar value:

```
curl 'https://no-more-json.shuttleapp.rs/api?url=https://wttr.in/Detroit?format=j1&q=.current_condition%5B0%5D.FeelsLikeC'
"27"
```

If we break down that url:

```
curl \
    'https://no-more-json.shuttleapp.rs/api    <-- endpoint for no-more-json
    ?url=https://wttr.in/Detroit?format=j1     <-- endpoint for the API we want data from
    &q=.current_condition%5B0%5D.FeelsLikeC'   <-- URL encoded jq query to extract the data
```

See more details in the [README](https://github.com/beyarkay/no-more-json)